### PR TITLE
Postgres location error

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,4 +1,6 @@
 param location string = resourceGroup().location
+@description('Location for PostgreSQL. Defaults to eastus due to availability restrictions in some regions.')
+param postgresLocation string = 'eastus'
 param applicationName string = 'pacman-app'
 param environment string = 'dev'
 @secure()
@@ -25,7 +27,7 @@ module acrModule 'modules/acr.bicep' = {
 module postgresModule 'modules/postgres.bicep' = {
   name: 'postgresDeploy'
   params: {
-    location: location
+    location: postgresLocation
     serverName: postgresServerName
     adminPassword: postgresAdminPassword
   }

--- a/infra/main.json
+++ b/infra/main.json
@@ -13,6 +13,13 @@
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
     },
+    "postgresLocation": {
+      "type": "string",
+      "defaultValue": "eastus",
+      "metadata": {
+        "description": "Location for PostgreSQL. Defaults to eastus due to availability restrictions in some regions."
+      }
+    },
     "applicationName": {
       "type": "string",
       "defaultValue": "pacman-app"
@@ -112,7 +119,7 @@
         "mode": "Incremental",
         "parameters": {
           "location": {
-            "value": "[parameters('location')]"
+            "value": "[parameters('postgresLocation')]"
           },
           "serverName": {
             "value": "[variables('postgresServerName')]"


### PR DESCRIPTION
Add `postgresLocation` parameter to fix PostgreSQL deployment failures caused by regional subscription restrictions.

The deployment was failing because PostgreSQL Flexible Server could not be provisioned in 'westeurope' due to `LocationIsOfferRestricted`. This change introduces a separate `postgresLocation` parameter, defaulting to 'eastus', allowing PostgreSQL to be deployed in an available region while the rest of the infrastructure remains in the primary location.

---
<a href="https://cursor.com/background-agent?bcId=bc-2de81543-937f-4117-b572-40414eda0cff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2de81543-937f-4117-b572-40414eda0cff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

