### PR TITLE
PostgreSQL name location conflict

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -13,8 +13,8 @@ var webAppName = 'app-${applicationName}-${environment}'
 var dockerImageName = 'pacman'
 var dockerImageTag = 'latest'
 
-
-var postgresServerName = 'psql-${uniqueSuffix}'
+// Include location in the postgres server name to ensure uniqueness when location changes
+var postgresServerName = 'psql-${uniqueString(resourceGroup().id, postgresLocation)}'
 
 module acrModule 'modules/acr.bicep' = {
   name: 'acrDeploy'

--- a/infra/main.json
+++ b/infra/main.json
@@ -39,7 +39,7 @@
     "webAppName": "[format('app-{0}-{1}', parameters('applicationName'), parameters('environment'))]",
     "dockerImageName": "pacman",
     "dockerImageTag": "latest",
-    "postgresServerName": "[format('psql-{0}', variables('uniqueSuffix'))]"
+    "postgresServerName": "[format('psql-{0}', uniqueString(resourceGroup().id, parameters('postgresLocation')))]"
   },
   "resources": [
     {


### PR DESCRIPTION
Update PostgreSQL server name generation to include location, resolving `InvalidResourceLocation` errors when deploying to different regions.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc069cad-9cee-4d89-b5c8-8adf341181df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bc069cad-9cee-4d89-b5c8-8adf341181df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

