### PR TITLE
Postgres deployment failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ on:
 env:
   RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
   LOCATION: ${{ vars.AZURE_LOCATION }}
+  POSTGRES_LOCATION: ${{ vars.AZURE_POSTGRES_LOCATION || 'westus2' }}
   DEPLOYMENT_NAME: pacman-deployment
 
 concurrency:
@@ -44,7 +45,7 @@ jobs:
           resourceGroupName: ${{ env.RESOURCE_GROUP }}
           template: ./infra/main.bicep
           deploymentName: ${{ env.DEPLOYMENT_NAME }}
-          parameters: postgresAdminPassword=${{ secrets.POSTGRES_ADMIN_PASSWORD }}
+          parameters: postgresAdminPassword=${{ secrets.POSTGRES_ADMIN_PASSWORD }} postgresLocation=${{ env.POSTGRES_LOCATION }}
 
       - name: Derive Deployment Outputs
         id: deploy_outputs

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,6 +1,6 @@
 param location string = resourceGroup().location
-@description('Location for PostgreSQL. Defaults to eastus due to availability restrictions in some regions.')
-param postgresLocation string = 'eastus'
+@description('Location for PostgreSQL. Defaults to westus2 due to availability restrictions in some regions.')
+param postgresLocation string = 'westus2'
 param applicationName string = 'pacman-app'
 param environment string = 'dev'
 @secure()

--- a/infra/main.json
+++ b/infra/main.json
@@ -15,9 +15,9 @@
     },
     "postgresLocation": {
       "type": "string",
-      "defaultValue": "eastus",
+      "defaultValue": "westus2",
       "metadata": {
-        "description": "Location for PostgreSQL. Defaults to eastus due to availability restrictions in some regions."
+        "description": "Location for PostgreSQL. Defaults to westus2 due to availability restrictions in some regions."
       }
     },
     "applicationName": {


### PR DESCRIPTION
Change default PostgreSQL location to `westus2` and enable override in workflow to fix deployment failures due to region restrictions.

The previous regions (`westeurope` and `eastus`) were restricted for PostgreSQL Flexible Server provisioning in the Azure subscription, leading to deployment failures. `westus2` is a more commonly available region, and the workflow update allows for easy overriding if `westus2` also becomes restricted.

---
<a href="https://cursor.com/background-agent?bcId=bc-092711f0-ab30-4c7d-a229-c7bb6bb5dce4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-092711f0-ab30-4c7d-a229-c7bb6bb5dce4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

