### PR TITLE
Arrow buttons initial visibility

### DIFF
--- a/frontend/src/game/Game.tsx
+++ b/frontend/src/game/Game.tsx
@@ -139,17 +139,25 @@ const Game: React.FC<GameProps> = ({ onLogout, onShowScoreboard, onOnlineCountCh
     
     if (waiting) {
         return (
-            <div className="game-board-centered">
-                <div className="waiting-screen">
-                    <h2>Waiting for opponent...</h2>
-                    <p>Online users: {lobbyStats.online_count}</p>
+            <div className="game-wrapper">
+                <div className="game-board-centered">
+                    <div className="waiting-screen">
+                        <h2>Waiting for opponent...</h2>
+                        <p>Online users: {lobbyStats.online_count}</p>
+                    </div>
                 </div>
+                <TouchControls onDirectionChange={handleDirectionInput} />
             </div>
         );
     }
 
     if (!gameState) {
-        return <div className="game-loading">Loading...</div>;
+        return (
+            <div className="game-wrapper">
+                <div className="game-loading">Loading...</div>
+                <TouchControls onDirectionChange={handleDirectionInput} />
+            </div>
+        );
     }
 
     const { grid, players, ghosts, score, gameOver, powerModeTime } = gameState;


### PR DESCRIPTION
Ensure mobile arrow buttons are always visible.

Previously, `TouchControls` were only rendered when `gameState` was available, meaning mobile users couldn't see the arrow buttons during the "Loading..." or "Waiting for opponent..." screens. This PR modifies `Game.tsx` to include `TouchControls` in these early return states, making them immediately visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-60b1901a-bf69-41c4-86b9-6ade5a8587e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-60b1901a-bf69-41c4-86b9-6ade5a8587e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

